### PR TITLE
Switched to sonarcloud contract

### DIFF
--- a/Sources/DBXCResultParser-Sonar/SonarGenericTestExecutionReportFormatter.swift
+++ b/Sources/DBXCResultParser-Sonar/SonarGenericTestExecutionReportFormatter.swift
@@ -108,8 +108,33 @@ fileprivate struct testExecutions: Encodable, DynamicNodeEncoding {
                 }
             }
             
-            struct skipped: Encodable { }
-            struct failure: Encodable { }
+            struct skipped: Encodable, DynamicNodeEncoding {
+                let message: String
+                
+                static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
+                    switch key {
+                    case
+                        Self.CodingKeys.message:
+                        return .attribute
+                    default:
+                        return .element
+                    }
+                }
+            }
+            
+            struct failure: Encodable, DynamicNodeEncoding {
+                let message: String
+                
+                static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
+                    switch key {
+                    case
+                        Self.CodingKeys.message:
+                        return .attribute
+                    default:
+                        return .element
+                    }
+                }
+            }
         }
     }
 }
@@ -119,8 +144,8 @@ extension testExecutions.file.testCase {
         self.init(
             name: test.name, 
             duration: Int(test.totalDuration.converted(to: .milliseconds).value),
-            skipped: test.combinedStatus == .skipped ? .init() : nil,
-            failure: test.combinedStatus == .failure ? .init() : nil
+            skipped: test.combinedStatus == .skipped ? .init(message: test.message ?? "Test message missing") : nil,
+            failure: test.combinedStatus == .failure ? .init(message: test.message ?? "Test message missing") : nil
         )
     }
 }

--- a/Tests/DBXCResultParser-SonarTests/SonarGenericTestExecutionReportFormatterTests.swift
+++ b/Tests/DBXCResultParser-SonarTests/SonarGenericTestExecutionReportFormatterTests.swift
@@ -32,14 +32,15 @@ class SonarGenericTestExecutionReportFormatterTests: XCTestCase {
         XCTAssertEqual(result, """
 <testExecutions version="1">
     <file path="./ClassName_a_a.swift">
-        <testCase name="test_a" duration="0">
-            <failure />
+        <testCase name="test_expecting_fail" duration="0" />
+        <testCase name="test_failure" duration="0">
+            <failure message="Failure message" />
         </testCase>
-        <testCase name="test_b" duration="0" />
-        <testCase name="test_c" duration="0" />
-        <testCase name="test_d" duration="0">
-            <skipped />
+        <testCase name="test_mixedFailureAndSuccess" duration="0" />
+        <testCase name="test_skipped" duration="0">
+            <skipped message="Skip message" />
         </testCase>
+        <testCase name="test_success" duration="0" />
     </file>
     <file path="./ClassName_a_b.swift" />
     <file path="./ClassName_a_c.swift" />
@@ -73,10 +74,11 @@ extension DBXCReportModel {
                 .testMake(
                     name: "ClassName_a_a",
                     repeatableTests: [
-                        .failed(named: "test_a"),
-                        .succeeded(named: "test_b"),
-                        .mixedFailedSucceeded(named: "test_c"),
-                        .skipped(named: "test_d")
+                        .failed(named: "test_failure", message: "Failure message"),
+                        .succeeded(named: "test_success"),
+                        .mixedFailedSucceeded(named: "test_mixedFailureAndSuccess"),
+                        .skipped(named: "test_skipped", message: "Skip message"),
+                        .expectedFailed(named: "test_expecting_fail", message: "Failure message")
                     ]
                 ),
                 .testMake(


### PR DESCRIPTION
Switched from [sonarqube contract](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution) to [sonarcloud contract](https://docs.sonarsource.com/sonarcloud/enriching/test-coverage/generic-test-data/#generic-execution)